### PR TITLE
Add a GitHub action for running e2e suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,25 @@
+name: e2e-suite
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '*.md'
+
+jobs:
+  e2e-pr-blocking:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19
+
+    - name: Install ginkgo
+      run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+
+    - name: Run PR-Blocking e2e tests
+      run: yes | GINKGO_FOCUS="\[PR-Blocking\]" make test-e2e


### PR DESCRIPTION
The e2e suite will run on every PR commit, this is useful to run the most important or basic e2e flows and make sure we don't cause any breaking changes