### PR TITLE
Add an additional rbac role to the DockerMachine controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
   - dockerclusters

--- a/controllers/dockermachine_controller.go
+++ b/controllers/dockermachine_controller.go
@@ -54,6 +54,7 @@ type DockerMachineReconciler struct {
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachines/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This fixes the error message from capdkc controller.
```bash
W1019 03:32:08.398963     170 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.Machine: machines.cluster.x-k8s.io is forbidden: User "system:serviceaccount:capdkc-system:capdkc-controller-manager" cannot list resource "machines" in API group "cluster.x-k8s.io" at the cluster scope
E1019 03:32:08.399330     170 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.Machine: failed to list *v1beta1.Machine: machines.cluster.x-k8s.io is forbidden: User "system:serviceaccount:capdkc-system:capdkc-controller-manager" cannot list resource "machines" in API group "cluster.x-k8s.io" at the cluster scope
```