### PR TITLE
Fix DockerMachine Condition Patching Conflict

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,6 @@ func main() {
 	if err = (&controllers.DockerMachineReconciler{
 		Client:           mgr.GetClient(),
 		ContainerRuntime: runtimeClient,
-		Scheme:           mgr.GetScheme(),
 		Tracker:          tracker,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DockerMachine")


### PR DESCRIPTION
This PR 
* Fixes an error patching conditions for a worker DockerMachine.
* Add a summary `Ready` condition to DockerMachine.

DockerMachine
```yaml
status:
  addresses:
  - address: kubecontest-md-0-5f7dfcfd84-zlvd7
    type: Hostname
  - address: 172.18.0.5
    type: InternalIP
  - address: 172.18.0.5
    type: ExternalIP
  conditions:
  - lastTransitionTime: "2022-10-20T16:14:37Z"
    reason: Bootstrapping
    severity: Info
    status: "False" ⬅️
    type: BootstrapExecSucceeded
  - lastTransitionTime: "2022-10-20T16:14:37Z"
    status: "True"
    type: ContainerProvisioned
  ready: true
```

capdkc log
* `error patching conditions: The condition \"BootstrapExecSucceeded\" was modified by a different process and this caused a merge/AddCondition conflict`
```bash
1.6663200209867823e+09	ERROR	failed to patch dockerMachine	{"controller": "dockermachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "DockerMachine", "dockerMachine": {"name":"kubecontest-md-0-k5zhq","namespace":"default"}, "namespace": "default", "name": "kubecontest-md-0-k5zhq", "reconcileID": "dff2b5e3-63ad-4705-9976-4f70cc95d9a8", "cluster": "kubecontest", "error": "error patching conditions: The condition \"BootstrapExecSucceeded\" was modified by a different process and this caused a merge/AddCondition conflict:   &v1beta1.Condition{\n  \tType:               \"BootstrapExecSucceeded\"
```

DockerMachine after the fix
```yaml
status:
  addresses:
  - address: kubecontest-md-0-5f7dfcfd84-gdmpr
    type: Hostname
  - address: 172.18.0.5
    type: InternalIP
  - address: 172.18.0.5
    type: ExternalIP
  conditions:
  - lastTransitionTime: "2022-10-21T03:21:22Z"
    status: "True"
    type: Ready ⬅️
  - lastTransitionTime: "2022-10-21T03:21:22Z"
    status: "True" ⬅️
    type: BootstrapExecSucceeded
  - lastTransitionTime: "2022-10-21T03:21:01Z"
    status: "True"
    type: ContainerProvisioned
  ready: true
```