### PR TITLE
Add printcolumns to DockerCluster and DockerMachine

### DIFF
--- a/api/v1alpha1/dockercluster_types.go
+++ b/api/v1alpha1/dockercluster_types.go
@@ -58,6 +58,9 @@ type DockerClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready"
+//+kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint"
 
 // DockerCluster is the Schema for the dockerclusters API
 type DockerCluster struct {

--- a/api/v1alpha1/dockermachine_types.go
+++ b/api/v1alpha1/dockermachine_types.go
@@ -90,6 +90,10 @@ type DockerMachineStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+//+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this DockerMachine"
+//+kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Machine ready status"
 
 // DockerMachine is the Schema for the dockermachines API
 type DockerMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -15,7 +15,20 @@ spec:
     singular: dockercluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Cluster infrastructure is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint
+      name: Endpoint
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DockerCluster is the Schema for the dockerclusters API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -15,7 +15,24 @@ spec:
     singular: dockermachine
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object which owns with this DockerMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DockerMachine is the Schema for the dockermachines API


### PR DESCRIPTION
Decided to add printcolumns to provide a user with summary info. Will update the tutorial.

```bash
➜  kubectl get dockercluster
NAME          CLUSTER       READY   ENDPOINT
kubecontest   kubecontest   true    {"host":"172.18.0.3","port":6443}

➜  kubectl get dockermachine
NAME                              CLUSTER       MACHINE                             PROVIDERID                                     READY
kubecontest-control-plane-lpn82   kubecontest   kubecontest-control-plane-ghz6h     docker:////kubecontest-control-plane-ghz6h     True
kubecontest-md-0-87d7c            kubecontest   kubecontest-md-0-5f7dfcfd84-gdmpr   docker:////kubecontest-md-0-5f7dfcfd84-gdmpr   True
```